### PR TITLE
docs: add note about no library target and correct test command usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,17 @@ cargo clippy -- -D warnings  # Lint check
 cargo test           # Run tests
 ```
 
+> [!IMPORTANT]
+> **No library target**: This project only has a `[[bin]]` target (`gws`), not a `[lib]` target. When running a subset of tests, use `--bin gws` instead of `--lib`.
+>
+> ```bash
+> # CORRECT
+> cargo test --bin gws mcp_server::permissions
+>
+> # WRONG — will fail with "no library targets found"
+> cargo test --lib mcp_server::permissions
+> ```
+
 ## Changesets
 
 Every PR must include a changeset file. Create one at `.changeset/<descriptive-name>.md`:


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. If adding a new feature or command, please include the output of running it with `--dry-run` to prove the JSON request body matches the Discovery Document schema.

**Dry Run Output:**
```json
// Paste --dry-run output here if applicable
```

## Checklist:

- [ ] My code follows the `AGENTS.md` guidelines (no generated `google-*` crates).
- [ ] I have run `cargo fmt --all` to format the code perfectly.
- [ ] I have run `cargo clippy -- -D warnings` and resolved all warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have provided a Changeset file (e.g. via `pnpx changeset`) to document my changes.
