### PR TITLE
feat: scope-based permissions with dual-layer access control

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,12 @@ Configure in your MCP client:
 
 ### Permission Control (HTTP Gateway)
 
-When running in HTTP transport mode as a multi-user gateway, you can restrict which API methods each user is allowed to call by providing a YAML permissions file.
+When running in HTTP transport mode as a multi-user gateway, you can restrict access per user by providing a YAML permissions file. The permission system uses a **two-layer model** — both layers are always checked:
+
+1. **OAuth scopes** — controls which Google API scopes the role can use.
+2. **Method patterns** — controls which specific API methods are allowed.
+
+A request is permitted only when it passes **both** checks. Roles must define both `scopes` and `method`; if either is empty the role denies all access.
 
 ```bash
 gws mcp -s all -t http \
@@ -358,38 +363,99 @@ export GWS_PERMISSIONS_FILE=config/permissions.yaml
 
 roles:
   admin:
-    allow:
-      - "*"                          # all methods
-
-  workspace-reader:
-    allow:
-      - "gmail.users.messages.list"
-      - "gmail.users.messages.get"
+    # Primary: which OAuth scopes this role can use
+    scopes:
+      - "https://www.googleapis.com/auth/drive"
+      - "https://www.googleapis.com/auth/gmail.readonly"
+      - "https://www.googleapis.com/auth/calendar"
+      - "https://www.googleapis.com/auth/spreadsheets"
+      - "https://www.googleapis.com/auth/documents"
+      - "https://www.googleapis.com/auth/presentations"
+      - "https://www.googleapis.com/auth/tasks"
+    # Secondary (optional): further restrict to specific methods
+    method:
       - "drive.files.list"
       - "drive.files.get"
-      - "calendar.events.list"
-      - "calendar.events.get"
+      - "drive.files.create"
+      # ...
 
-  gmail-full:
-    allow:
-      - "gmail.*"                    # all Gmail methods
+  reader:
+    scopes:
+      - "https://www.googleapis.com/auth/drive.readonly"
+      - "https://www.googleapis.com/auth/gmail.readonly"
+      - "https://www.googleapis.com/auth/calendar.readonly"
+    method:
+      - "drive.files.list"
+      - "drive.files.get"
+      - "gmail.users.messages.list"
+      - "calendar.events.list"
+      # ...
 
 users:
   admin@company.com:
     role: admin
-
-  tanaka@company.com:
-    role: workspace-reader
-
-  suzuki@company.com:
-    role: gmail-full
+  reader@company.com:
+    role: reader
 ```
 
-#### Method IDs
+#### How the two layers work
+
+Both `scopes` and `method` are always checked. A request is allowed only when:
+
+1. At least one of the method's required OAuth scopes is present in the role's `scopes`
+2. The method ID matches at least one of the role's `method` patterns
+
+If either `scopes` or `method` is empty/missing in the role definition, the role denies all access.
+
+**Example:** A role with `drive.readonly` scope and `method: ["drive.files.list", "drive.files.get"]` can call those two methods (both accept `drive.readonly`) but cannot call `drive.files.create` (not in method list) or `gmail.users.messages.list` (scope mismatch).
+
+#### OAuth scope narrowing
+
+When a permissions file is loaded, the gateway automatically narrows the OAuth consent screen to only request the **union of all role scopes** (plus `openid email profile`). This applies the principle of least privilege — the gateway token only carries scopes that at least one role needs.
+
+You can override this by explicitly setting `--oauth-scopes`:
+
+```bash
+# Auto-narrowed from permissions (recommended)
+gws mcp -s all -t http --permissions-file config/permissions.yaml ...
+
+# Manual override (ignores permissions scopes)
+gws mcp -s all -t http --oauth-scopes "openid email profile https://www.googleapis.com/auth/drive" ...
+```
+
+> [!IMPORTANT]
+> **Token-level downscoping is not possible** for Google Workspace APIs.
+> Google's Credential Access Boundary (CAB) only supports Cloud Storage.
+> The gateway enforces scope restrictions at the application layer — the OAuth
+> token itself carries the union of all role scopes, but the gateway blocks
+> requests to methods outside the user's permitted scopes.
+
+#### Scope reference
+
+Common Google Workspace OAuth scopes:
+
+| Scope | Access level |
+|---|---|
+| `https://www.googleapis.com/auth/drive` | Full Drive access |
+| `https://www.googleapis.com/auth/drive.readonly` | Read-only Drive access |
+| `https://www.googleapis.com/auth/gmail.modify` | Read/write Gmail (no send/delete) |
+| `https://www.googleapis.com/auth/gmail.readonly` | Read-only Gmail |
+| `https://www.googleapis.com/auth/calendar` | Full Calendar access |
+| `https://www.googleapis.com/auth/calendar.readonly` | Read-only Calendar |
+| `https://www.googleapis.com/auth/spreadsheets` | Full Sheets access |
+| `https://www.googleapis.com/auth/spreadsheets.readonly` | Read-only Sheets |
+| `https://www.googleapis.com/auth/documents` | Full Docs access |
+| `https://www.googleapis.com/auth/documents.readonly` | Read-only Docs |
+| `https://www.googleapis.com/auth/presentations` | Full Slides access |
+| `https://www.googleapis.com/auth/presentations.readonly` | Read-only Slides |
+| `https://www.googleapis.com/auth/tasks` | Full Tasks access |
+| `https://www.googleapis.com/auth/tasks.readonly` | Read-only Tasks |
+
+Each API method declares which scopes it accepts in the Discovery Document. For example, `drive.files.list` accepts both `drive` and `drive.readonly`. The method is allowed if the role has **at least one** of the method's accepted scopes.
+
+#### Method patterns
 
 Method IDs follow the naming from Google's Discovery JSON (e.g. `drive.files.list`, `gmail.users.messages.send`). You can inspect available method IDs with `gws schema <method_id>`.
-
-#### Wildcard patterns
 
 | Pattern                      | Matches                                           |
 | ---------------------------- | ------------------------------------------------- |
@@ -403,6 +469,7 @@ Method IDs follow the naming from Google's Discovery JSON (e.g. `drive.files.lis
 - **HTTP mode only** — OAuth authentication and permission control are only supported in HTTP transport mode (`-t http`). In stdio mode these options are ignored (a warning is printed).
 - **Unregistered users** (email not in `users:`) are denied all access — `tools/list` returns an empty list and `tools/call` returns a permission error.
 - **No permissions file** — all authenticated users have full access (backwards-compatible).
+- **Missing scopes or method in role** — the role denies all access. Both must be defined.
 
 ## Advanced Usage
 

--- a/config/permissions.yaml
+++ b/config/permissions.yaml
@@ -1,6 +1,14 @@
 roles:
   admin:
-    allow:
+    scopes:
+      - "https://www.googleapis.com/auth/drive"
+      - "https://www.googleapis.com/auth/gmail.readonly"
+      - "https://www.googleapis.com/auth/calendar"
+      - "https://www.googleapis.com/auth/spreadsheets"
+      - "https://www.googleapis.com/auth/documents"
+      - "https://www.googleapis.com/auth/presentations"
+      - "https://www.googleapis.com/auth/tasks"
+    method:
       # =============================================
       # Drive v3 (45/55 — delete/権限変更系を除外)
       # =============================================
@@ -63,42 +71,43 @@ roles:
       # drive.teamdrives.delete        — 除外（drives.delete と同等）
 
       # =============================================
-      # Gmail v1 (22/76 — send/delete/settings系を除外)
+      # Gmail v1 (閲覧のみ — gmail.readonly スコープ)
+      # gmail.modify が必要なメソッドは全除外
       # =============================================
-      - "gmail.users.drafts.create"
       - "gmail.users.drafts.get"
       - "gmail.users.drafts.list"
-      - "gmail.users.drafts.update"
-      # gmail.users.drafts.send        — 除外（下書き送信）
-      # gmail.users.drafts.delete      — 除外
+      # gmail.users.drafts.create      — 除外（gmail.modify 必要）
+      # gmail.users.drafts.update      — 除外（gmail.modify 必要）
+      # gmail.users.drafts.send        — 除外（gmail.modify 必要）
+      # gmail.users.drafts.delete      — 除外（gmail.modify 必要）
       - "gmail.users.getProfile"
       - "gmail.users.history.list"
-      - "gmail.users.labels.create"
       - "gmail.users.labels.get"
       - "gmail.users.labels.list"
-      - "gmail.users.labels.patch"
-      - "gmail.users.labels.update"
-      # gmail.users.labels.delete      — 除外
+      # gmail.users.labels.create      — 除外（gmail.modify 必要）
+      # gmail.users.labels.patch       — 除外（gmail.modify 必要）
+      # gmail.users.labels.update      — 除外（gmail.modify 必要）
+      # gmail.users.labels.delete      — 除外（gmail.modify 必要）
       - "gmail.users.messages.attachments.get"
       - "gmail.users.messages.get"
-      - "gmail.users.messages.import"
-      - "gmail.users.messages.insert"
       - "gmail.users.messages.list"
-      - "gmail.users.messages.untrash"
-      # gmail.users.messages.send      — 除外（メール送信）
-      # gmail.users.messages.delete    — 除外（完全削除）
-      # gmail.users.messages.batchDelete — 除外（一括完全削除）
-      # gmail.users.messages.trash     — 除外
-      # gmail.users.messages.modify    — 除外
-      # gmail.users.messages.batchModify — 除外
-      - "gmail.users.stop"
+      # gmail.users.messages.import    — 除外（gmail.modify 必要）
+      # gmail.users.messages.insert    — 除外（gmail.modify 必要）
+      # gmail.users.messages.untrash   — 除外（gmail.modify 必要）
+      # gmail.users.messages.send      — 除外（gmail.modify 必要）
+      # gmail.users.messages.delete    — 除外（gmail.modify 必要）
+      # gmail.users.messages.batchDelete — 除外（gmail.modify 必要）
+      # gmail.users.messages.trash     — 除外（gmail.modify 必要）
+      # gmail.users.messages.modify    — 除外（gmail.modify 必要）
+      # gmail.users.messages.batchModify — 除外（gmail.modify 必要）
       - "gmail.users.threads.get"
       - "gmail.users.threads.list"
-      - "gmail.users.threads.untrash"
-      # gmail.users.threads.delete     — 除外（完全削除）
-      # gmail.users.threads.trash      — 除外
-      # gmail.users.threads.modify     — 除外
-      - "gmail.users.watch"
+      # gmail.users.threads.untrash    — 除外（gmail.modify 必要）
+      # gmail.users.threads.delete     — 除外（gmail.modify 必要）
+      # gmail.users.threads.trash      — 除外（gmail.modify 必要）
+      # gmail.users.threads.modify     — 除外（gmail.modify 必要）
+      # gmail.users.stop               — 除外（gmail.modify 必要）
+      # gmail.users.watch              — 除外（gmail.modify 必要）
       # gmail.users.settings.*         — 全除外（転送/フィルター/委任等）
 
       # =============================================
@@ -192,7 +201,15 @@ roles:
       - "slides.presentations.pages.getThumbnail"
 
   reader:
-    allow:
+    scopes:
+      - "https://www.googleapis.com/auth/drive.readonly"
+      - "https://www.googleapis.com/auth/gmail.readonly"
+      - "https://www.googleapis.com/auth/calendar.readonly"
+      - "https://www.googleapis.com/auth/spreadsheets.readonly"
+      - "https://www.googleapis.com/auth/documents.readonly"
+      - "https://www.googleapis.com/auth/presentations.readonly"
+      - "https://www.googleapis.com/auth/tasks.readonly"
+    method:
       # Drive — 閲覧のみ
       - "drive.about.get"
       - "drive.files.list"

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -338,6 +338,30 @@ pub async fn start(args: &[String]) -> Result<(), GwsError> {
         None => None,
     };
 
+    // When permissions define scopes and the user did not explicitly set
+    // --oauth-scopes, narrow the OAuth consent to the union of all role
+    // scopes.  This ensures the gateway token only carries the scopes that
+    // at least one role needs (principle of least privilege).
+    let oauth_config = match (oauth_config, &permissions_config) {
+        (Some(mut oc), Some(pc)) => {
+            let user_explicitly_set = matches.value_source("oauth-scopes")
+                == Some(clap::parser::ValueSource::CommandLine);
+            let union = pc.all_scopes_union();
+            if !user_explicitly_set && !union.is_empty() {
+                let mut scopes = vec!["openid".to_string(), "email".to_string(), "profile".to_string()];
+                for s in union {
+                    if !scopes.contains(&s) {
+                        scopes.push(s);
+                    }
+                }
+                oc.scopes = scopes.join(" ");
+                eprintln!("[gws mcp] OAuth scopes narrowed to permissions union: {}", oc.scopes);
+            }
+            Some(oc)
+        }
+        (oc, _) => oc,
+    };
+
     match transport {
         "http" => {
             // OAuth and permissions are only supported in HTTP transport mode.
@@ -403,8 +427,20 @@ async fn handle_request(
             }
             let all_tools = cache.as_ref().unwrap();
 
-            // Phase 6: Filter tools by user permissions when configured.
-            let tools = filter_tools_by_permissions(all_tools, perm_ctx);
+            // Filter tools by user permissions (scopes + optional allow patterns).
+            let filtered = filter_tools_by_permissions(all_tools, perm_ctx);
+
+            // Strip internal `_scopes` metadata before sending to the client.
+            let tools: Vec<Value> = filtered
+                .into_iter()
+                .map(|t| {
+                    let mut t = t.clone();
+                    if let Some(obj) = t.as_object_mut() {
+                        obj.remove("_scopes");
+                    }
+                    t
+                })
+                .collect();
 
             Ok(json!({
                 "tools": tools
@@ -531,11 +567,19 @@ fn walk_resources(prefix: &str, resources: &HashMap<String, RestResource>, tools
                 }
             });
 
-            tools.push(json!({
+            let mut tool = json!({
                 "name": tool_name,
                 "description": description,
                 "inputSchema": input_schema
-            }));
+            });
+
+            // Attach method scopes as internal metadata for permission filtering.
+            // This field is stripped before sending to the client.
+            if !method.scopes.is_empty() {
+                tool["_scopes"] = json!(method.scopes);
+            }
+
+            tools.push(tool);
         }
 
         // Recurse into sub-resources
@@ -555,19 +599,6 @@ async fn handle_tools_call(
         .get("name")
         .and_then(|n| n.as_str())
         .ok_or_else(|| GwsError::Validation("Missing 'name' in tools/call".to_string()))?;
-
-    // Phase 5: Check permissions before executing the tool.
-    if let Some(perms) = perm_ctx.permissions {
-        if let Some(email) = perm_ctx.user_email {
-            let method_id = tool_name_to_method_id(tool_name);
-            if !perms.is_method_allowed(email, &method_id) {
-                return Err(GwsError::Validation(format!(
-                    "Permission denied: '{}' is not allowed for user '{}'",
-                    method_id, email
-                )));
-            }
-        }
-    }
 
     let default_args = json!({});
     let arguments = params.get("arguments").unwrap_or(&default_args);
@@ -623,6 +654,19 @@ async fn handle_tools_call(
     } else {
         return Err(GwsError::Validation("Resource not found".to_string()));
     };
+
+    // Check permissions (scopes + optional allow patterns) before executing.
+    if let Some(perms) = perm_ctx.permissions {
+        if let Some(email) = perm_ctx.user_email {
+            let method_id = tool_name_to_method_id(tool_name);
+            if !perms.is_method_allowed_with_scopes(email, &method_id, &method.scopes) {
+                return Err(GwsError::Validation(format!(
+                    "Permission denied: '{}' is not allowed for user '{}'",
+                    method_id, email
+                )));
+            }
+        }
+    }
 
     let params_json_val = arguments.get("params");
     let params_str = params_json_val

--- a/src/mcp_server/permissions.rs
+++ b/src/mcp_server/permissions.rs
@@ -16,11 +16,26 @@ pub struct PermissionsConfig {
     pub users: HashMap<String, UserDef>,
 }
 
-/// A role definition containing allowed method ID patterns.
+/// A role definition containing allowed OAuth scopes and method ID patterns.
+///
+/// `scopes` is the primary access control layer — it determines which OAuth
+/// scopes the role is allowed to use.  At tool-execution time the method's
+/// required scopes (from the Discovery Document) are checked against the
+/// role's scopes; the request is allowed only when at least one of the
+/// method's scopes is present in the role.
+///
+/// `method` specifies which API method IDs (with optional wildcards) the role
+/// is allowed to call.
+///
+/// Both `scopes` and `method` are always checked.  A request is allowed only
+/// when it passes **both** the scope check and the method-pattern check.
+/// If either list is empty the corresponding check fails (deny-by-default).
 #[derive(Debug, Deserialize, Clone)]
 pub struct RoleDef {
     #[serde(default)]
-    pub allow: Vec<String>,
+    pub scopes: Vec<String>,
+    #[serde(default)]
+    pub method: Vec<String>,
 }
 
 /// A user definition referencing a role name.
@@ -61,19 +76,86 @@ impl PermissionsConfig {
 
     /// Get the allowed method patterns for a user.
     /// Returns `None` if the user is not registered (unregistered users get nothing).
+    #[cfg(test)]
     pub fn get_allowed_patterns(&self, email: &str) -> Option<&[String]> {
         let user_def = self.users.get(email)?;
         let role_def = self.roles.get(&user_def.role)?;
-        Some(&role_def.allow)
+        Some(&role_def.method)
     }
 
-    /// Check if a specific method ID is allowed for the given user.
+    /// Get the allowed OAuth scopes for a user.
+    /// Returns `None` if the user is not registered.
+    #[cfg(test)]
+    pub fn get_allowed_scopes(&self, email: &str) -> Option<&[String]> {
+        let user_def = self.users.get(email)?;
+        let role_def = self.roles.get(&user_def.role)?;
+        Some(&role_def.scopes)
+    }
+
+    /// Check if a method is allowed for the given user based on both scope
+    /// and (optionally) method-pattern checks.
+    ///
+    /// Convenience wrapper over [`is_method_allowed_with_scopes`] with an
+    /// empty method-scope list (scope check is skipped).
+    ///
     /// Returns `false` for unregistered users.
+    #[cfg(test)]
     pub fn is_method_allowed(&self, email: &str, method_id: &str) -> bool {
-        match self.get_allowed_patterns(email) {
-            Some(patterns) => patterns.iter().any(|p| matches_pattern(p, method_id)),
-            None => false,
+        self.is_method_allowed_with_scopes(email, method_id, &[])
+    }
+
+    /// Like [`is_method_allowed`] but also checks the method's required
+    /// OAuth scopes against the role's allowed scopes.
+    pub fn is_method_allowed_with_scopes(
+        &self,
+        email: &str,
+        method_id: &str,
+        method_scopes: &[String],
+    ) -> bool {
+        let user_def = match self.users.get(email) {
+            Some(u) => u,
+            None => return false,
+        };
+        let role_def = match self.roles.get(&user_def.role) {
+            Some(r) => r,
+            None => return false,
+        };
+
+        // Scope check: role must have scopes and at least one must match.
+        if role_def.scopes.is_empty() {
+            return false;
         }
+        if !method_scopes.is_empty() {
+            let scope_ok = method_scopes
+                .iter()
+                .any(|ms| role_def.scopes.iter().any(|rs| rs == ms));
+            if !scope_ok {
+                return false;
+            }
+        }
+
+        // Method-pattern check: role must have patterns and method must match.
+        if role_def.method.is_empty() {
+            return false;
+        }
+        role_def.method.iter().any(|p| matches_pattern(p, method_id))
+    }
+
+    /// Return the union of all scopes across every role.
+    ///
+    /// This is used to compute the minimal OAuth scope set for the gateway's
+    /// Google OAuth consent screen when permissions are configured.
+    pub fn all_scopes_union(&self) -> Vec<String> {
+        let mut seen = std::collections::HashSet::new();
+        let mut result = Vec::new();
+        for role_def in self.roles.values() {
+            for scope in &role_def.scopes {
+                if seen.insert(scope.clone()) {
+                    result.push(scope.clone());
+                }
+            }
+        }
+        result
     }
 
     /// Filter a list of method IDs to only those allowed for the given user.
@@ -123,9 +205,13 @@ pub(super) struct PermissionContext<'a> {
     pub permissions: Option<&'a PermissionsConfig>,
 }
 
-/// Phase 6: Filter the tools list based on user permissions.
+/// Filter the tools list based on user permissions (scopes + method patterns).
 /// Returns all tools if no permissions are configured.
 /// Returns empty list for unregistered users when permissions are configured.
+///
+/// Each tool's JSON value may contain a `_scopes` array (internal metadata,
+/// stripped before sending to the client) that lists the OAuth scopes the
+/// underlying API method requires.
 pub(super) fn filter_tools_by_permissions<'a>(
     tools: &'a [Value],
     perm_ctx: &PermissionContext<'_>,
@@ -140,10 +226,19 @@ pub(super) fn filter_tools_by_permissions<'a>(
         None => return tools.iter().collect(), // Local mode -> all tools
     };
 
-    let patterns = match perms.get_allowed_patterns(email) {
-        Some(p) => p,
+    let user_def = match perms.users.get(email) {
+        Some(u) => u,
         None => return vec![], // Unregistered user -> empty list
     };
+    let role_def = match perms.roles.get(&user_def.role) {
+        Some(r) => r,
+        None => return vec![], // Missing role -> empty list
+    };
+
+    // Both scopes and method must be defined on the role.
+    if role_def.scopes.is_empty() || role_def.method.is_empty() {
+        return vec![];
+    }
 
     tools
         .iter()
@@ -153,9 +248,29 @@ pub(super) fn filter_tools_by_permissions<'a>(
                 .and_then(|n| n.as_str())
                 .unwrap_or("");
             let method_id = tool_name_to_method_id(tool_name);
-            patterns
-                .iter()
-                .any(|p| matches_pattern(p, &method_id))
+
+            // Scope check.
+            let method_scopes: Vec<String> = tool
+                .get("_scopes")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|s| s.as_str().map(|s| s.to_string()))
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            if !method_scopes.is_empty() {
+                let scope_ok = method_scopes
+                    .iter()
+                    .any(|ms| role_def.scopes.iter().any(|rs| rs == ms));
+                if !scope_ok {
+                    return false;
+                }
+            }
+
+            // Method-pattern check.
+            role_def.method.iter().any(|p| matches_pattern(p, &method_id))
         })
         .collect()
 }
@@ -217,10 +332,10 @@ mod tests {
         let yaml = r#"
 roles:
   admin:
-    allow:
+    method:
       - "*"
   reader:
-    allow:
+    method:
       - "drive.files.list"
       - "drive.files.get"
 
@@ -240,7 +355,7 @@ users:
         let yaml = r#"
 roles:
   admin:
-    allow:
+    method:
       - "*"
 
 users:
@@ -256,7 +371,10 @@ users:
         let yaml = r#"
 roles:
   admin:
-    allow:
+    scopes:
+      - "https://www.googleapis.com/auth/drive"
+      - "https://www.googleapis.com/auth/gmail.modify"
+    method:
       - "*"
 
 users:
@@ -273,7 +391,9 @@ users:
         let yaml = r#"
 roles:
   reader:
-    allow:
+    scopes:
+      - "https://www.googleapis.com/auth/drive.readonly"
+    method:
       - "drive.files.list"
       - "drive.files.get"
 
@@ -292,7 +412,9 @@ users:
         let yaml = r#"
 roles:
   admin:
-    allow:
+    scopes:
+      - "https://www.googleapis.com/auth/drive"
+    method:
       - "*"
 
 users:
@@ -308,7 +430,7 @@ users:
         let yaml = r#"
 roles:
   reader:
-    allow:
+    method:
       - "drive.files.*"
 
 users:
@@ -334,7 +456,7 @@ users:
         let yaml = r#"
 roles:
   admin:
-    allow:
+    method:
       - "*"
 
 users:
@@ -392,7 +514,7 @@ users: {}
             json!({"name": "drive_files_list", "description": "List files"}),
         ];
         let perms = PermissionsConfig::parse(
-            "roles:\n  admin:\n    allow:\n      - \"*\"\nusers:\n  admin@co.com:\n    role: admin\n",
+            "roles:\n  admin:\n    scopes:\n      - \"https://www.googleapis.com/auth/drive\"\n    method:\n      - \"*\"\nusers:\n  admin@co.com:\n    role: admin\n",
         )
         .unwrap();
         let perm_ctx = PermissionContext {
@@ -411,7 +533,7 @@ users: {}
             json!({"name": "gmail_users_messages_send", "description": "Send email"}),
         ];
         let perms = PermissionsConfig::parse(
-            "roles:\n  admin:\n    allow:\n      - \"*\"\nusers:\n  admin@co.com:\n    role: admin\n",
+            "roles:\n  admin:\n    scopes:\n      - \"https://www.googleapis.com/auth/drive\"\n    method:\n      - \"*\"\nusers:\n  admin@co.com:\n    role: admin\n",
         )
         .unwrap();
         let perm_ctx = PermissionContext {
@@ -434,7 +556,9 @@ users: {}
         let yaml = r#"
 roles:
   reader:
-    allow:
+    scopes:
+      - "https://www.googleapis.com/auth/drive.readonly"
+    method:
       - "drive.files.list"
       - "drive.files.get"
 users:
@@ -464,7 +588,9 @@ users:
         let yaml = r#"
 roles:
   gmail-user:
-    allow:
+    scopes:
+      - "https://www.googleapis.com/auth/gmail.modify"
+    method:
       - "gmail.*"
 users:
   user@co.com:
@@ -486,7 +612,7 @@ users:
             json!({"name": "drive_files_list", "description": "List files"}),
         ];
         let perms = PermissionsConfig::parse(
-            "roles:\n  admin:\n    allow:\n      - \"*\"\nusers:\n  admin@co.com:\n    role: admin\n",
+            "roles:\n  admin:\n    scopes:\n      - \"https://www.googleapis.com/auth/drive\"\n    method:\n      - \"*\"\nusers:\n  admin@co.com:\n    role: admin\n",
         )
         .unwrap();
         // No user email (local mode) -> all tools visible
@@ -496,5 +622,309 @@ users:
         };
         let filtered = filter_tools_by_permissions(&tools, &perm_ctx);
         assert_eq!(filtered.len(), 1);
+    }
+
+    // ── Scope-based permission tests ──
+
+    #[test]
+    fn test_parse_yaml_with_scopes() {
+        let yaml = r#"
+roles:
+  editor:
+    scopes:
+      - "https://www.googleapis.com/auth/drive"
+      - "https://www.googleapis.com/auth/gmail.modify"
+    method:
+      - "drive.*"
+  viewer:
+    scopes:
+      - "https://www.googleapis.com/auth/drive.readonly"
+
+users:
+  editor@co.com:
+    role: editor
+  viewer@co.com:
+    role: viewer
+"#;
+        let config = PermissionsConfig::parse(yaml).unwrap();
+        assert_eq!(config.roles["editor"].scopes.len(), 2);
+        assert_eq!(config.roles["viewer"].scopes.len(), 1);
+        assert!(config.roles["viewer"].method.is_empty());
+    }
+
+    #[test]
+    fn test_get_allowed_scopes() {
+        let yaml = r#"
+roles:
+  viewer:
+    scopes:
+      - "https://www.googleapis.com/auth/drive.readonly"
+users:
+  viewer@co.com:
+    role: viewer
+"#;
+        let config = PermissionsConfig::parse(yaml).unwrap();
+        let scopes = config.get_allowed_scopes("viewer@co.com").unwrap();
+        assert_eq!(scopes, &["https://www.googleapis.com/auth/drive.readonly"]);
+        assert!(config.get_allowed_scopes("unknown@co.com").is_none());
+    }
+
+    #[test]
+    fn test_is_method_allowed_with_scopes_matching() {
+        let yaml = r#"
+roles:
+  editor:
+    scopes:
+      - "https://www.googleapis.com/auth/drive"
+    method:
+      - "drive.*"
+users:
+  user@co.com:
+    role: editor
+"#;
+        let config = PermissionsConfig::parse(yaml).unwrap();
+        // Method requires drive scope — allowed
+        assert!(config.is_method_allowed_with_scopes(
+            "user@co.com",
+            "drive.files.list",
+            &["https://www.googleapis.com/auth/drive".to_string(),
+              "https://www.googleapis.com/auth/drive.readonly".to_string()],
+        ));
+    }
+
+    #[test]
+    fn test_is_method_allowed_with_scopes_denied() {
+        let yaml = r#"
+roles:
+  viewer:
+    scopes:
+      - "https://www.googleapis.com/auth/drive.readonly"
+    method:
+      - "drive.*"
+users:
+  user@co.com:
+    role: viewer
+"#;
+        let config = PermissionsConfig::parse(yaml).unwrap();
+        // Method requires gmail scope — denied (user only has drive.readonly)
+        assert!(!config.is_method_allowed_with_scopes(
+            "user@co.com",
+            "gmail.users.messages.list",
+            &["https://www.googleapis.com/auth/gmail.modify".to_string()],
+        ));
+    }
+
+    #[test]
+    fn test_is_method_allowed_with_scopes_plus_method_pattern() {
+        let yaml = r#"
+roles:
+  restricted:
+    scopes:
+      - "https://www.googleapis.com/auth/drive"
+    method:
+      - "drive.files.list"
+      - "drive.files.get"
+users:
+  user@co.com:
+    role: restricted
+"#;
+        let config = PermissionsConfig::parse(yaml).unwrap();
+        let drive_scopes = vec!["https://www.googleapis.com/auth/drive".to_string()];
+        // Scope matches AND method matches → allowed
+        assert!(config.is_method_allowed_with_scopes(
+            "user@co.com", "drive.files.list", &drive_scopes,
+        ));
+        // Scope matches BUT method doesn't match → denied
+        assert!(!config.is_method_allowed_with_scopes(
+            "user@co.com", "drive.files.create", &drive_scopes,
+        ));
+    }
+
+    #[test]
+    fn test_empty_scopes_denies_all() {
+        let yaml = r#"
+roles:
+  no-scopes:
+    method:
+      - "drive.files.*"
+users:
+  user@co.com:
+    role: no-scopes
+"#;
+        let config = PermissionsConfig::parse(yaml).unwrap();
+        // No scopes defined → always denied
+        assert!(!config.is_method_allowed_with_scopes(
+            "user@co.com",
+            "drive.files.list",
+            &["https://www.googleapis.com/auth/drive".to_string()],
+        ));
+    }
+
+    #[test]
+    fn test_empty_method_denies_all() {
+        let yaml = r#"
+roles:
+  no-method:
+    scopes:
+      - "https://www.googleapis.com/auth/drive"
+users:
+  user@co.com:
+    role: no-method
+"#;
+        let config = PermissionsConfig::parse(yaml).unwrap();
+        // No method patterns defined → always denied
+        assert!(!config.is_method_allowed_with_scopes(
+            "user@co.com",
+            "drive.files.list",
+            &["https://www.googleapis.com/auth/drive".to_string()],
+        ));
+    }
+
+    #[test]
+    fn test_all_scopes_union() {
+        let yaml = r#"
+roles:
+  editor:
+    scopes:
+      - "https://www.googleapis.com/auth/drive"
+      - "https://www.googleapis.com/auth/gmail.modify"
+  viewer:
+    scopes:
+      - "https://www.googleapis.com/auth/drive.readonly"
+      - "https://www.googleapis.com/auth/drive"
+users:
+  e@co.com:
+    role: editor
+  v@co.com:
+    role: viewer
+"#;
+        let config = PermissionsConfig::parse(yaml).unwrap();
+        let union = config.all_scopes_union();
+        // drive appears in both roles but should be deduplicated
+        assert!(union.contains(&"https://www.googleapis.com/auth/drive".to_string()));
+        assert!(union.contains(&"https://www.googleapis.com/auth/gmail.modify".to_string()));
+        assert!(union.contains(&"https://www.googleapis.com/auth/drive.readonly".to_string()));
+        assert_eq!(union.len(), 3);
+    }
+
+    #[test]
+    fn test_all_scopes_union_empty() {
+        let yaml = r#"
+roles:
+  legacy:
+    method:
+      - "*"
+users:
+  user@co.com:
+    role: legacy
+"#;
+        let config = PermissionsConfig::parse(yaml).unwrap();
+        assert!(config.all_scopes_union().is_empty());
+    }
+
+    #[test]
+    fn test_filter_tools_by_scopes_and_method() {
+        use serde_json::json;
+        let tools = vec![
+            json!({
+                "name": "drive_files_list",
+                "description": "List files",
+                "_scopes": ["https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/drive.readonly"]
+            }),
+            json!({
+                "name": "gmail_users_messages_list",
+                "description": "List messages",
+                "_scopes": ["https://www.googleapis.com/auth/gmail.modify", "https://www.googleapis.com/auth/gmail.readonly"]
+            }),
+        ];
+        let yaml = r#"
+roles:
+  drive-only:
+    scopes:
+      - "https://www.googleapis.com/auth/drive.readonly"
+    method:
+      - "drive.*"
+users:
+  user@co.com:
+    role: drive-only
+"#;
+        let perms = PermissionsConfig::parse(yaml).unwrap();
+        let perm_ctx = PermissionContext {
+            user_email: Some("user@co.com"),
+            permissions: Some(&perms),
+        };
+        let filtered = filter_tools_by_permissions(&tools, &perm_ctx);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0]["name"], "drive_files_list");
+    }
+
+    #[test]
+    fn test_filter_tools_scopes_plus_method() {
+        use serde_json::json;
+        let tools = vec![
+            json!({
+                "name": "drive_files_list",
+                "description": "List files",
+                "_scopes": ["https://www.googleapis.com/auth/drive"]
+            }),
+            json!({
+                "name": "drive_files_create",
+                "description": "Create file",
+                "_scopes": ["https://www.googleapis.com/auth/drive"]
+            }),
+            json!({
+                "name": "gmail_users_messages_list",
+                "description": "List messages",
+                "_scopes": ["https://www.googleapis.com/auth/gmail.modify"]
+            }),
+        ];
+        let yaml = r#"
+roles:
+  restricted:
+    scopes:
+      - "https://www.googleapis.com/auth/drive"
+    method:
+      - "drive.files.list"
+users:
+  user@co.com:
+    role: restricted
+"#;
+        let perms = PermissionsConfig::parse(yaml).unwrap();
+        let perm_ctx = PermissionContext {
+            user_email: Some("user@co.com"),
+            permissions: Some(&perms),
+        };
+        let filtered = filter_tools_by_permissions(&tools, &perm_ctx);
+        // Only drive_files_list: scope matches AND method matches
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0]["name"], "drive_files_list");
+    }
+
+    #[test]
+    fn test_both_scopes_and_method_required() {
+        let yaml = r#"
+roles:
+  scopes-only:
+    scopes:
+      - "https://www.googleapis.com/auth/drive"
+  method-only:
+    method:
+      - "drive.*"
+users:
+  s@co.com:
+    role: scopes-only
+  m@co.com:
+    role: method-only
+"#;
+        let config = PermissionsConfig::parse(yaml).unwrap();
+        let drive_scopes = vec!["https://www.googleapis.com/auth/drive".to_string()];
+        // scopes-only role: denied because no method patterns
+        assert!(!config.is_method_allowed_with_scopes(
+            "s@co.com", "drive.files.list", &drive_scopes,
+        ));
+        // method-only role: denied because no scopes
+        assert!(!config.is_method_allowed_with_scopes(
+            "m@co.com", "drive.files.list", &drive_scopes,
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- **Two-layer permission model**: roles must define both `scopes` (OAuth scopes) and `method` (API method patterns). Both are always checked — if either is missing, the role denies all access.
- **OAuth scope narrowing**: when a permissions file is loaded, the gateway auto-computes the union of all role scopes for the OAuth consent screen (principle of least privilege).
- **Renamed `allow` → `method`** in YAML config, Rust code (`RoleDef` struct), and all tests for clarity.
- **Removed `gmail.modify` scope** from admin role — Gmail access is now read-only (`gmail.readonly`).
- **`_scopes` metadata on tools**: each tool carries its required scopes from the Discovery Document, used for scope-based filtering at `tools/list` and `tools/call` time.
- **README updated** with full permission system documentation: YAML format, two-layer behavior, scope reference table, and method pattern syntax.

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (513 tests)
- [x] New tests for: empty scopes denies all, empty method denies all, both required, scope+method intersection, scope narrowing union

🤖 Generated with [Claude Code](https://claude.com/claude-code)