### PR TITLE
feat: slim GWS MCP tools and introduce member role

### DIFF
--- a/config/permissions.yaml
+++ b/config/permissions.yaml
@@ -2,151 +2,57 @@ roles:
   admin:
     scopes:
       - "https://www.googleapis.com/auth/drive"
-      - "https://www.googleapis.com/auth/gmail.readonly"
-      - "https://www.googleapis.com/auth/calendar"
       - "https://www.googleapis.com/auth/spreadsheets"
       - "https://www.googleapis.com/auth/documents"
       - "https://www.googleapis.com/auth/presentations"
       - "https://www.googleapis.com/auth/tasks"
     method:
       # =============================================
-      # Drive v3 (45/55 — delete/権限変更系を除外)
+      # Drive v3 (6 — files 操作のみ残存)
+      # Calendar/Gmail は専用コネクタで完全代替のため全削除
+      # その他の Drive リソース（changes, comments, drives,
+      # permissions, replies, revisions, teamdrives 等）も削除
       # =============================================
-      - "drive.about.get"
-      - "drive.accessproposals.get"
-      - "drive.accessproposals.list"
-      - "drive.accessproposals.resolve"
-      - "drive.approvals.get"
-      - "drive.approvals.list"
-      - "drive.apps.get"
-      - "drive.apps.list"
-      - "drive.changes.getStartPageToken"
-      - "drive.changes.list"
-      - "drive.changes.watch"
-      - "drive.channels.stop"
-      - "drive.comments.create"
-      - "drive.comments.get"
-      - "drive.comments.list"
-      - "drive.comments.update"
-      # drive.comments.delete          — 除外
-      - "drive.drives.get"
-      - "drive.drives.hide"
-      - "drive.drives.list"
-      - "drive.drives.unhide"
-      - "drive.drives.update"
-      # drive.drives.create            — 除外（共有ドライブ新規作成）
-      # drive.drives.delete            — 除外（共有ドライブ削除）
-      - "drive.files.copy"
-      - "drive.files.create"
-      # - "drive.files.download"       - 除外（downloadは非同期APIのため、MCPでは使用しない）
-      - "drive.files.export"
-      - "drive.files.generateIds"
-      - "drive.files.get"
       - "drive.files.list"
-      - "drive.files.listLabels"
-      - "drive.files.modifyLabels"
+      - "drive.files.get"
+      - "drive.files.create"
+      - "drive.files.copy"
       - "drive.files.update"
-      - "drive.files.watch"
-      # drive.files.delete             — 除外（完全削除）
-      # drive.files.emptyTrash         — 除外（ゴミ箱全消去）
-      - "drive.operations.get"
-      - "drive.permissions.get"
-      - "drive.permissions.list"
-      # drive.permissions.create       — 除外（外部共有リスク）
-      # drive.permissions.update       — 除外（オーナー移転）
-      # drive.permissions.delete       — 除外（アクセス権剥奪）
-      - "drive.replies.create"
-      - "drive.replies.get"
-      - "drive.replies.list"
-      - "drive.replies.update"
-      # drive.replies.delete           — 除外
-      - "drive.revisions.get"
-      - "drive.revisions.list"
-      - "drive.revisions.update"
-      # drive.revisions.delete         — 除外（バージョン履歴削除）
-      - "drive.teamdrives.get"
-      - "drive.teamdrives.list"
-      - "drive.teamdrives.update"
-      # drive.teamdrives.create        — 除外（drives.create と同等）
-      # drive.teamdrives.delete        — 除外（drives.delete と同等）
+      - "drive.files.export"
 
       # =============================================
-      # Gmail v1 (閲覧のみ — gmail.readonly スコープ)
-      # gmail.modify が必要なメソッドは全除外
+      # Sheets v4 (11 — DataFilter/developerMetadata 系を削除)
       # =============================================
-      - "gmail.users.drafts.get"
-      - "gmail.users.drafts.list"
-      # gmail.users.drafts.create      — 除外（gmail.modify 必要）
-      # gmail.users.drafts.update      — 除外（gmail.modify 必要）
-      # gmail.users.drafts.send        — 除外（gmail.modify 必要）
-      # gmail.users.drafts.delete      — 除外（gmail.modify 必要）
-      - "gmail.users.getProfile"
-      - "gmail.users.history.list"
-      - "gmail.users.labels.get"
-      - "gmail.users.labels.list"
-      # gmail.users.labels.create      — 除外（gmail.modify 必要）
-      # gmail.users.labels.patch       — 除外（gmail.modify 必要）
-      # gmail.users.labels.update      — 除外（gmail.modify 必要）
-      # gmail.users.labels.delete      — 除外（gmail.modify 必要）
-      - "gmail.users.messages.attachments.get"
-      - "gmail.users.messages.get"
-      - "gmail.users.messages.list"
-      # gmail.users.messages.import    — 除外（gmail.modify 必要）
-      # gmail.users.messages.insert    — 除外（gmail.modify 必要）
-      # gmail.users.messages.untrash   — 除外（gmail.modify 必要）
-      # gmail.users.messages.send      — 除外（gmail.modify 必要）
-      # gmail.users.messages.delete    — 除外（gmail.modify 必要）
-      # gmail.users.messages.batchDelete — 除外（gmail.modify 必要）
-      # gmail.users.messages.trash     — 除外（gmail.modify 必要）
-      # gmail.users.messages.modify    — 除外（gmail.modify 必要）
-      # gmail.users.messages.batchModify — 除外（gmail.modify 必要）
-      - "gmail.users.threads.get"
-      - "gmail.users.threads.list"
-      # gmail.users.threads.untrash    — 除外（gmail.modify 必要）
-      # gmail.users.threads.delete     — 除外（gmail.modify 必要）
-      # gmail.users.threads.trash      — 除外（gmail.modify 必要）
-      # gmail.users.threads.modify     — 除外（gmail.modify 必要）
-      # gmail.users.stop               — 除外（gmail.modify 必要）
-      # gmail.users.watch              — 除外（gmail.modify 必要）
-      # gmail.users.settings.*         — 全除外（転送/フィルター/委任等）
+      - "sheets.spreadsheets.batchUpdate"
+      - "sheets.spreadsheets.create"
+      - "sheets.spreadsheets.get"
+      - "sheets.spreadsheets.sheets.copyTo"
+      - "sheets.spreadsheets.values.append"
+      - "sheets.spreadsheets.values.batchClear"
+      - "sheets.spreadsheets.values.batchGet"
+      - "sheets.spreadsheets.values.batchUpdate"
+      - "sheets.spreadsheets.values.clear"
+      - "sheets.spreadsheets.values.get"
+      - "sheets.spreadsheets.values.update"
 
       # =============================================
-      # Calendar v3 (27/37 — delete/clear/acl系を除外)
+      # Docs v1 (3/3 — 全許可) [変更なし]
       # =============================================
-      - "calendar.calendarList.delete"
-      - "calendar.calendarList.get"
-      - "calendar.calendarList.insert"
-      - "calendar.calendarList.list"
-      - "calendar.calendarList.patch"
-      - "calendar.calendarList.update"
-      - "calendar.calendarList.watch"
-      - "calendar.calendars.get"
-      - "calendar.calendars.insert"
-      - "calendar.calendars.patch"
-      - "calendar.calendars.update"
-      # calendar.calendars.clear       — 除外（全予定一括削除）
-      # calendar.calendars.delete      — 除外（カレンダー削除）
-      - "calendar.channels.stop"
-      - "calendar.colors.get"
-      - "calendar.events.get"
-      - "calendar.events.import"
-      - "calendar.events.insert"
-      - "calendar.events.instances"
-      - "calendar.events.list"
-      - "calendar.events.move"
-      - "calendar.events.patch"
-      - "calendar.events.quickAdd"
-      - "calendar.events.update"
-      - "calendar.events.watch"
-      # calendar.events.delete         — 除外
-      - "calendar.freebusy.query"
-      - "calendar.settings.get"
-      - "calendar.settings.list"
-      - "calendar.settings.watch"
-      # calendar.acl.*                 — 全除外（アクセス制御変更）
+      - "docs.documents.batchUpdate"
+      - "docs.documents.create"
+      - "docs.documents.get"
 
       # =============================================
-      # Tasks v1 (14/14 — 全許可)
+      # Slides v1 (5/5 — 全許可) [変更なし]
+      # =============================================
+      - "slides.presentations.batchUpdate"
+      - "slides.presentations.create"
+      - "slides.presentations.get"
+      - "slides.presentations.pages.get"
+      - "slides.presentations.pages.getThumbnail"
+
+      # =============================================
+      # Tasks v1 (全許可) [変更なし]
       # =============================================
       - "tasks.tasklists.delete"
       - "tasks.tasklists.get"
@@ -163,158 +69,62 @@ roles:
       - "tasks.tasks.patch"
       - "tasks.tasks.update"
 
-      # =============================================
-      # Sheets v4 (17/17 — 全許可)
-      # =============================================
-      - "sheets.spreadsheets.batchUpdate"
-      - "sheets.spreadsheets.create"
-      - "sheets.spreadsheets.developerMetadata.get"
-      - "sheets.spreadsheets.developerMetadata.search"
-      - "sheets.spreadsheets.get"
-      - "sheets.spreadsheets.getByDataFilter"
-      - "sheets.spreadsheets.sheets.copyTo"
-      - "sheets.spreadsheets.values.append"
-      - "sheets.spreadsheets.values.batchClear"
-      - "sheets.spreadsheets.values.batchClearByDataFilter"
-      - "sheets.spreadsheets.values.batchGet"
-      - "sheets.spreadsheets.values.batchGetByDataFilter"
-      - "sheets.spreadsheets.values.batchUpdate"
-      - "sheets.spreadsheets.values.batchUpdateByDataFilter"
-      - "sheets.spreadsheets.values.clear"
-      - "sheets.spreadsheets.values.get"
-      - "sheets.spreadsheets.values.update"
-
-      # =============================================
-      # Docs v1 (3/3 — 全許可)
-      # =============================================
-      - "docs.documents.batchUpdate"
-      - "docs.documents.create"
-      - "docs.documents.get"
-
-      # =============================================
-      # Slides v1 (5/5 — 全許可)
-      # =============================================
+  member:
+    scopes:
+      - "https://www.googleapis.com/auth/drive.readonly"
+      - "https://www.googleapis.com/auth/drive.file"
+      - "https://www.googleapis.com/auth/spreadsheets.readonly"
+      - "https://www.googleapis.com/auth/documents.readonly"
+      - "https://www.googleapis.com/auth/presentations"
+      - "https://www.googleapis.com/auth/tasks.readonly"
+    method:
+      # Drive — 全ファイル閲覧 + MCP作成分の書き込み
+      - "drive.files.list"
+      - "drive.files.get"
+      - "drive.files.export"
+      - "drive.files.create"
+      - "drive.files.update"
+      # Slides — フルアクセス（作成・編集）
       - "slides.presentations.batchUpdate"
       - "slides.presentations.create"
       - "slides.presentations.get"
       - "slides.presentations.pages.get"
       - "slides.presentations.pages.getThumbnail"
-
-  reader:
-    scopes:
-      - "https://www.googleapis.com/auth/drive.readonly"
-      - "https://www.googleapis.com/auth/gmail.readonly"
-      - "https://www.googleapis.com/auth/calendar.readonly"
-      - "https://www.googleapis.com/auth/spreadsheets.readonly"
-      - "https://www.googleapis.com/auth/documents.readonly"
-      - "https://www.googleapis.com/auth/presentations.readonly"
-      - "https://www.googleapis.com/auth/tasks.readonly"
-    method:
-      # Drive — 閲覧のみ
-      - "drive.about.get"
-      - "drive.files.list"
-      - "drive.files.get"
-      - "drive.files.export"
-      - "drive.files.download"
-      - "drive.files.listLabels"
-      - "drive.permissions.list"
-      - "drive.permissions.get"
-      - "drive.comments.list"
-      - "drive.comments.get"
-      - "drive.replies.list"
-      - "drive.replies.get"
-      - "drive.drives.list"
-      - "drive.drives.get"
-      - "drive.revisions.list"
-      - "drive.revisions.get"
-      - "drive.teamdrives.list"
-      - "drive.teamdrives.get"
-      - "drive.changes.list"
-      - "drive.changes.getStartPageToken"
-      # Gmail — 閲覧のみ
-      - "gmail.users.getProfile"
-      - "gmail.users.messages.list"
-      - "gmail.users.messages.get"
-      - "gmail.users.messages.attachments.get"
-      - "gmail.users.labels.list"
-      - "gmail.users.labels.get"
-      - "gmail.users.threads.list"
-      - "gmail.users.threads.get"
-      - "gmail.users.history.list"
-      - "gmail.users.drafts.list"
-      - "gmail.users.drafts.get"
-      # Calendar — 閲覧のみ
-      - "calendar.events.list"
-      - "calendar.events.get"
-      - "calendar.events.instances"
-      - "calendar.calendarList.list"
-      - "calendar.calendarList.get"
-      - "calendar.calendars.get"
-      - "calendar.colors.get"
-      - "calendar.freebusy.query"
-      - "calendar.settings.list"
-      - "calendar.settings.get"
+      # Sheets — 閲覧のみ
+      - "sheets.spreadsheets.get"
+      - "sheets.spreadsheets.values.get"
+      - "sheets.spreadsheets.values.batchGet"
+      # Docs — 閲覧のみ
+      - "docs.documents.get"
       # Tasks — 閲覧のみ
       - "tasks.tasklists.list"
       - "tasks.tasklists.get"
       - "tasks.tasks.list"
       - "tasks.tasks.get"
-      # Sheets — 閲覧のみ
-      - "sheets.spreadsheets.get"
-      - "sheets.spreadsheets.getByDataFilter"
-      - "sheets.spreadsheets.values.get"
-      - "sheets.spreadsheets.values.batchGet"
-      - "sheets.spreadsheets.values.batchGetByDataFilter"
-      - "sheets.spreadsheets.developerMetadata.get"
-      - "sheets.spreadsheets.developerMetadata.search"
-      # Docs — 閲覧のみ
-      - "docs.documents.get"
-      # Slides — 閲覧のみ
-      - "slides.presentations.get"
-      - "slides.presentations.pages.get"
-      - "slides.presentations.pages.getThumbnail"
 
 users:
   # ── admin ──
-  hiroki.tahara@hodl1.jp:
-    role: admin
   kosuke.ito@hodl1.jp:
     role: admin
   ryo.tanaka@hodl1.jp:
     role: admin
+  hiroki.tahara@hodl1.jp:
+    role: admin
   takuya.oshima@hodl1.jp:
     role: admin
-  daisuke.takenaka@hodl1.jp:
-    role: admin
-  takahiro.ishihama@hodl1.jp:
+  keisuke.funatsu@hodl1.jp:
     role: admin
   yusuke.egami@hodl1.jp:
-    role: admin
-  keisuke.funatsu@hodl1.jp:
     role: admin
   noriko.kitano@hodl1.jp:
     role: admin
 
-  # ── reader ──
-  hisao.araki@hodl1.jp:
-    role: reader
-  osamu.watanabe@hodl1.jp:
-    role: reader
-  kensuke.sato@hodl1.jp:
-    role: reader
-  hajime.hosaka@hodl1.jp:
-    role: reader
-  yosuke.naito@hodl1.jp:
-    role: reader
-  tomofumi.nakasone@hodl1.jp:
-    role: reader
-  taichi.sano@hodl1.jp:
-    role: reader
+  # ── member ──
+  is@kushim.co.jp:
+    role: member
   miki.kitazawa@hodl1.jp:
-    role: reader
-  hodaka.goto@hodl1.jp:
-    role: reader
-  mihoko.egami@hodl1.jp:
-    role: reader
-  junichi.ishigaki@hodl1.jp:
-    role: reader
+    role: member
+  yosuke.naito@hodl1.jp:
+    role: member
+  takahiro.uehara@hodl1.jp:
+    role: member


### PR DESCRIPTION
## Summary
- Calendar全27ツール・Gmail全11ツールを削除（専用コネクタで完全代替）
- Driveツールを45→6に削減（files.list/get/create/copy/update/exportのみ残存）
- Sheets DataFilter/developerMetadata系6ツールを削除
- readerロールをmemberにリネームし、Slides作成・編集権限とDriveファイル操作権限を追加（スコープ: `drive.file` + `drive.readonly` + `presentations`）
- ユーザーリストを現行Claudeシート保有者に同期（admin 7名、member 4名）

## Test plan
- [ ] admin ユーザーでログインし、Drive/Sheets/Docs/Slides/Tasks の各ツールが想定通り見えることを確認
- [ ] member ユーザーでログインし、Slides 作成・編集、Drive files 操作が可能なことを確認
- [ ] member ユーザーで Calendar/Gmail ツールが表示されないことを確認
- [ ] 削除対象ユーザーでログインした場合、ツールが一切表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)