### PR TITLE
feat: extract text from binary documents in MCP responses

### DIFF
--- a/.changeset/binary-text-extraction.md
+++ b/.changeset/binary-text-extraction.md
@@ -1,0 +1,5 @@
+---
+"@googleworkspace/cli": minor
+---
+
+Extract text from binary documents (DOCX, XLSX, PPTX, PDF) in MCP server responses instead of returning resource blobs that Claude cannot process

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "adobe-cmap-parser"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8abfa9a4688de8fc9f42b3f013b6fffec18ed8a554f5f113577e0b9b3212a3"
+dependencies = [
+ "pom",
+]
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,6 +131,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "async-trait"
@@ -244,10 +268,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -277,6 +316,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,6 +333,12 @@ dependencies = [
  "find-msvc-tools",
  "shlex",
 ]
+
+[[package]]
+name = "cff-parser"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f5b6e9141c036f3ff4ce7b2f7e432b0f00dee416ddcd4f17741d189ddc2e9d"
 
 [[package]]
 name = "cfg-if"
@@ -433,6 +487,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -593,6 +656,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,10 +777,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "ecb"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equivalent"
@@ -722,6 +814,15 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "euclid"
+version = "0.20.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bb7ef65b3777a325d1eeefefab5b6d4959da54747e33bd6258e789640f307ad"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -777,6 +878,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -969,7 +1080,9 @@ dependencies = [
  "keyring",
  "mail-builder",
  "mime_guess2",
+ "pdf-extract",
  "percent-encoding",
+ "quick-xml",
  "rand 0.8.5",
  "ratatui",
  "reqwest",
@@ -991,6 +1104,7 @@ dependencies = [
  "uuid",
  "yup-oauth2",
  "zeroize",
+ "zip",
 ]
 
 [[package]]
@@ -1328,6 +1442,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
 
@@ -1492,6 +1607,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lopdf"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7184fdea2bc3cd272a1acec4030c321a8f9875e877b3f92a53f2f6033fdc289"
+dependencies = [
+ "aes",
+ "bitflags 2.11.0",
+ "cbc",
+ "ecb",
+ "encoding_rs",
+ "flate2",
+ "getrandom 0.3.4",
+ "indexmap",
+ "itoa",
+ "log",
+ "md-5",
+ "nom 8.0.0",
+ "nom_locate",
+ "rand 0.9.2",
+ "rangemap",
+ "sha2",
+ "stringprep",
+ "thiserror 2.0.18",
+ "ttf-parser",
+ "weezl",
+]
+
+[[package]]
 name = "lru"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,6 +1684,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1586,6 +1739,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1618,6 +1781,26 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "nom_locate"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b577e2d69827c4740cba2b52efaad1c4cc7c73042860b199710b3575c68438d"
+dependencies = [
+ "bytecount",
+ "memchr",
+ "nom 8.0.0",
 ]
 
 [[package]]
@@ -1724,6 +1907,23 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pdf-extract"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28ba1758a3d3f361459645780e09570b573fc3c82637449e9963174c813a98"
+dependencies = [
+ "adobe-cmap-parser",
+ "cff-parser",
+ "encoding_rs",
+ "euclid 0.20.14",
+ "log",
+ "lopdf",
+ "postscript",
+ "type1-encoding-parser",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -1872,10 +2072,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pom"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60f6ce597ecdcc9a098e7fddacb1065093a3d66446fa16c675e7e71d1b5c28e6"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "postscript"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78451badbdaebaf17f053fd9152b3ffb33b516104eacb45e7864aaa9c712f306"
 
 [[package]]
 name = "potential_utf"
@@ -1918,6 +2130,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2054,6 +2275,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rangemap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "ratatui"
@@ -2578,6 +2805,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2616,6 +2849,17 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -2712,7 +2956,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
- "nom",
+ "nom 7.1.3",
  "phf 0.11.3",
  "phf_codegen",
 ]
@@ -3066,6 +3310,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
+name = "type1-encoding-parser"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa10c302f5a53b7ad27fd42a3996e23d096ba39b5b8dd6d9e683a05b01bee749"
+dependencies = [
+ "pom",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3084,10 +3343,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -3358,6 +3638,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "wezterm-bidi"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3423,7 +3709,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
 dependencies = [
  "bitflags 1.3.2",
- "euclid",
+ "euclid 0.22.14",
  "lazy_static",
  "serde",
  "wezterm-dynamic",
@@ -3969,7 +4255,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 tracing-appender = "0.2"
 uuid = { version = "1.22.0", features = ["v4", "v5"] }
 mime_guess2 = "2.3.1"
+zip = { version = "2", default-features = false, features = ["deflate"] }
+quick-xml = "0.37"
+pdf-extract = "0.10"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 keyring = { version = "3.6.3", features = ["apple-native"] }

--- a/src/extraction.rs
+++ b/src/extraction.rs
@@ -1,0 +1,949 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Text extraction from binary document formats (DOCX, XLSX, PPTX, PDF).
+//!
+//! Used by the MCP server to convert binary API responses into text content
+//! blocks that Claude can process, instead of returning `resource` blobs
+//! that get silently discarded by the MCP client.
+
+use std::collections::HashMap;
+use std::io::Read;
+
+/// Maximum character count (~100k tokens) before truncation.
+const MAX_CHARS: usize = 400_000;
+
+const TRUNCATION_NOTICE: &str = "\n\n[Content truncated: exceeded 100,000 token limit]";
+
+#[derive(Debug, thiserror::Error)]
+pub enum ExtractionError {
+    #[error("ZIP archive error: {0}")]
+    Zip(String),
+    #[error("XML parsing error: {0}")]
+    Xml(String),
+    #[error("PDF extraction error: {0}")]
+    Pdf(String),
+}
+
+/// Returns `true` when the MIME type is a format we can extract text from.
+pub fn is_extractable_mime(mime: &str) -> bool {
+    let base = mime.split(';').next().unwrap_or(mime).trim();
+    matches!(
+        base,
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+            | "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            | "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+            | "application/pdf"
+    )
+}
+
+/// Attempt to extract text from binary document bytes based on MIME type.
+///
+/// Returns `Ok(Some(text))` if extraction succeeds, `Ok(None)` if the MIME
+/// type is not supported for extraction, and `Err(...)` if extraction was
+/// attempted but failed.
+pub fn extract_text(mime: &str, data: &[u8]) -> Result<Option<String>, ExtractionError> {
+    let base = mime.split(';').next().unwrap_or(mime).trim();
+    let text = match base {
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document" => {
+            extract_docx(data)?
+        }
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" => extract_xlsx(data)?,
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation" => {
+            extract_pptx(data)?
+        }
+        "application/pdf" => extract_pdf(data)?,
+        _ => return Ok(None),
+    };
+    Ok(Some(truncate_to_limit(text)))
+}
+
+// ---------------------------------------------------------------------------
+// DOCX extraction
+// ---------------------------------------------------------------------------
+
+fn extract_docx(data: &[u8]) -> Result<String, ExtractionError> {
+    let cursor = std::io::Cursor::new(data);
+    let mut archive =
+        zip::ZipArchive::new(cursor).map_err(|e| ExtractionError::Zip(e.to_string()))?;
+
+    let mut xml_str = String::new();
+    archive
+        .by_name("word/document.xml")
+        .map_err(|e| ExtractionError::Zip(e.to_string()))?
+        .read_to_string(&mut xml_str)
+        .map_err(|e| ExtractionError::Xml(e.to_string()))?;
+
+    let mut reader = quick_xml::Reader::from_str(&xml_str);
+    let mut result = String::new();
+    let mut paragraph_text = String::new();
+    let mut in_paragraph = false;
+    let mut in_text_elem = false;
+
+    loop {
+        match reader.read_event() {
+            Ok(quick_xml::events::Event::Start(ref e)) => {
+                let local = e.local_name();
+                if local.as_ref() == b"p" {
+                    in_paragraph = true;
+                    paragraph_text.clear();
+                } else if local.as_ref() == b"t" && in_paragraph {
+                    in_text_elem = true;
+                }
+            }
+            Ok(quick_xml::events::Event::Text(ref e)) if in_text_elem => {
+                if let Ok(text) = e.unescape() {
+                    paragraph_text.push_str(&text);
+                }
+            }
+            Ok(quick_xml::events::Event::End(ref e)) => {
+                let local = e.local_name();
+                if local.as_ref() == b"t" {
+                    in_text_elem = false;
+                } else if local.as_ref() == b"p" {
+                    if !paragraph_text.is_empty() {
+                        if !result.is_empty() {
+                            result.push('\n');
+                        }
+                        result.push_str(&paragraph_text);
+                    }
+                    in_paragraph = false;
+                }
+            }
+            Ok(quick_xml::events::Event::Eof) => break,
+            Err(e) => return Err(ExtractionError::Xml(e.to_string())),
+            _ => {}
+        }
+    }
+    Ok(result)
+}
+
+// ---------------------------------------------------------------------------
+// PPTX extraction
+// ---------------------------------------------------------------------------
+
+fn extract_pptx(data: &[u8]) -> Result<String, ExtractionError> {
+    let cursor = std::io::Cursor::new(data);
+    let mut archive =
+        zip::ZipArchive::new(cursor).map_err(|e| ExtractionError::Zip(e.to_string()))?;
+
+    let mut slide_names: Vec<String> = (0..archive.len())
+        .filter_map(|i| {
+            let name = archive.by_index(i).ok()?.name().to_string();
+            if name.starts_with("ppt/slides/slide") && name.ends_with(".xml") {
+                Some(name)
+            } else {
+                None
+            }
+        })
+        .collect();
+    slide_names.sort_by_key(|n| extract_slide_number(n));
+
+    let mut result = String::new();
+    for (i, slide_name) in slide_names.iter().enumerate() {
+        let mut xml_str = String::new();
+        archive
+            .by_name(slide_name)
+            .map_err(|e| ExtractionError::Zip(e.to_string()))?
+            .read_to_string(&mut xml_str)
+            .map_err(|e| ExtractionError::Xml(e.to_string()))?;
+
+        let slide_text = extract_drawing_text(&xml_str)?;
+        if !result.is_empty() {
+            result.push('\n');
+        }
+        result.push_str(&format!("## Slide {}", i + 1));
+        if slide_text.is_empty() {
+            result.push_str("\n(no text)");
+        } else {
+            result.push('\n');
+            result.push_str(&slide_text);
+        }
+        result.push('\n');
+    }
+    Ok(result)
+}
+
+fn extract_slide_number(path: &str) -> u32 {
+    path.trim_start_matches("ppt/slides/slide")
+        .trim_end_matches(".xml")
+        .parse()
+        .unwrap_or(u32::MAX)
+}
+
+/// Extract text from DrawingML XML (`<a:p>` / `<a:t>` elements).
+fn extract_drawing_text(xml: &str) -> Result<String, ExtractionError> {
+    let mut reader = quick_xml::Reader::from_str(xml);
+    let mut result = String::new();
+    let mut paragraph_text = String::new();
+    let mut in_paragraph = false;
+    let mut in_text_elem = false;
+
+    loop {
+        match reader.read_event() {
+            Ok(quick_xml::events::Event::Start(ref e)) => {
+                let local = e.local_name();
+                if local.as_ref() == b"p" {
+                    in_paragraph = true;
+                    paragraph_text.clear();
+                } else if local.as_ref() == b"t" && in_paragraph {
+                    in_text_elem = true;
+                }
+            }
+            Ok(quick_xml::events::Event::Text(ref e)) if in_text_elem => {
+                if let Ok(text) = e.unescape() {
+                    paragraph_text.push_str(&text);
+                }
+            }
+            Ok(quick_xml::events::Event::End(ref e)) => {
+                let local = e.local_name();
+                if local.as_ref() == b"t" {
+                    in_text_elem = false;
+                } else if local.as_ref() == b"p" {
+                    if !paragraph_text.is_empty() {
+                        if !result.is_empty() {
+                            result.push('\n');
+                        }
+                        result.push_str(&paragraph_text);
+                    }
+                    in_paragraph = false;
+                }
+            }
+            Ok(quick_xml::events::Event::Eof) => break,
+            Err(e) => return Err(ExtractionError::Xml(e.to_string())),
+            _ => {}
+        }
+    }
+    Ok(result)
+}
+
+// ---------------------------------------------------------------------------
+// XLSX extraction
+// ---------------------------------------------------------------------------
+
+fn extract_xlsx(data: &[u8]) -> Result<String, ExtractionError> {
+    let cursor = std::io::Cursor::new(data);
+    let mut archive =
+        zip::ZipArchive::new(cursor).map_err(|e| ExtractionError::Zip(e.to_string()))?;
+
+    // 1. Parse shared strings
+    let shared_strings = parse_shared_strings(&mut archive)?;
+
+    // 2. Parse workbook relationships (rId → file path)
+    let rel_map = parse_workbook_rels(&mut archive)?;
+
+    // 3. Parse workbook to get ordered sheet list
+    let sheets = parse_workbook_sheets(&mut archive, &rel_map)?;
+
+    // 4. Extract each sheet as a Markdown table
+    let mut output = String::new();
+    for sheet in &sheets {
+        let mut xml_str = String::new();
+        let sheet_path = &sheet.path;
+        match archive.by_name(sheet_path) {
+            Ok(mut file) => {
+                file.read_to_string(&mut xml_str)
+                    .map_err(|e| ExtractionError::Xml(e.to_string()))?;
+            }
+            Err(_) => continue,
+        }
+
+        let rows = parse_sheet_rows(&xml_str, &shared_strings)?;
+        if !output.is_empty() {
+            output.push('\n');
+        }
+        output.push_str(&format!("## Sheet: {}\n", sheet.name));
+        if rows.is_empty() {
+            output.push_str("(empty sheet)\n");
+            continue;
+        }
+        output.push_str(&format_rows_as_markdown(&rows));
+        output.push('\n');
+    }
+    Ok(output)
+}
+
+fn parse_shared_strings(
+    archive: &mut zip::ZipArchive<std::io::Cursor<&[u8]>>,
+) -> Result<Vec<String>, ExtractionError> {
+    let mut xml_str = String::new();
+    match archive.by_name("xl/sharedStrings.xml") {
+        Ok(mut file) => {
+            file.read_to_string(&mut xml_str)
+                .map_err(|e| ExtractionError::Xml(e.to_string()))?;
+        }
+        Err(_) => return Ok(Vec::new()),
+    }
+
+    let mut reader = quick_xml::Reader::from_str(&xml_str);
+    let mut strings = Vec::new();
+    let mut in_si = false;
+    let mut in_t = false;
+    let mut current = String::new();
+
+    loop {
+        match reader.read_event() {
+            Ok(quick_xml::events::Event::Start(ref e)) => {
+                let local = e.local_name();
+                if local.as_ref() == b"si" {
+                    in_si = true;
+                    current.clear();
+                } else if local.as_ref() == b"t" && in_si {
+                    in_t = true;
+                }
+            }
+            Ok(quick_xml::events::Event::Text(ref e)) if in_t => {
+                if let Ok(text) = e.unescape() {
+                    current.push_str(&text);
+                }
+            }
+            Ok(quick_xml::events::Event::End(ref e)) => {
+                let local = e.local_name();
+                if local.as_ref() == b"t" {
+                    in_t = false;
+                } else if local.as_ref() == b"si" {
+                    strings.push(std::mem::take(&mut current));
+                    in_si = false;
+                }
+            }
+            Ok(quick_xml::events::Event::Eof) => break,
+            Err(e) => return Err(ExtractionError::Xml(e.to_string())),
+            _ => {}
+        }
+    }
+    Ok(strings)
+}
+
+fn parse_workbook_rels(
+    archive: &mut zip::ZipArchive<std::io::Cursor<&[u8]>>,
+) -> Result<HashMap<String, String>, ExtractionError> {
+    let mut xml_str = String::new();
+    archive
+        .by_name("xl/_rels/workbook.xml.rels")
+        .map_err(|e| ExtractionError::Zip(e.to_string()))?
+        .read_to_string(&mut xml_str)
+        .map_err(|e| ExtractionError::Xml(e.to_string()))?;
+
+    let mut reader = quick_xml::Reader::from_str(&xml_str);
+    let mut map = HashMap::new();
+
+    loop {
+        match reader.read_event() {
+            Ok(quick_xml::events::Event::Start(ref e) | quick_xml::events::Event::Empty(ref e)) => {
+                if e.local_name().as_ref() == b"Relationship" {
+                    let mut id = None;
+                    let mut target = None;
+                    for attr in e.attributes().flatten() {
+                        match attr.key.as_ref() {
+                            b"Id" => id = Some(String::from_utf8_lossy(&attr.value).to_string()),
+                            b"Target" => {
+                                target = Some(String::from_utf8_lossy(&attr.value).to_string())
+                            }
+                            _ => {}
+                        }
+                    }
+                    if let (Some(id), Some(target)) = (id, target) {
+                        map.insert(id, target);
+                    }
+                }
+            }
+            Ok(quick_xml::events::Event::Eof) => break,
+            Err(e) => return Err(ExtractionError::Xml(e.to_string())),
+            _ => {}
+        }
+    }
+    Ok(map)
+}
+
+struct SheetInfo {
+    name: String,
+    path: String,
+}
+
+fn parse_workbook_sheets(
+    archive: &mut zip::ZipArchive<std::io::Cursor<&[u8]>>,
+    rel_map: &HashMap<String, String>,
+) -> Result<Vec<SheetInfo>, ExtractionError> {
+    let mut xml_str = String::new();
+    archive
+        .by_name("xl/workbook.xml")
+        .map_err(|e| ExtractionError::Zip(e.to_string()))?
+        .read_to_string(&mut xml_str)
+        .map_err(|e| ExtractionError::Xml(e.to_string()))?;
+
+    let mut reader = quick_xml::Reader::from_str(&xml_str);
+    let mut sheets = Vec::new();
+
+    loop {
+        match reader.read_event() {
+            Ok(quick_xml::events::Event::Start(ref e) | quick_xml::events::Event::Empty(ref e)) => {
+                if e.local_name().as_ref() == b"sheet" {
+                    let mut name = None;
+                    let mut r_id = None;
+                    for attr in e.attributes().flatten() {
+                        match attr.key.as_ref() {
+                            b"name" => {
+                                name = Some(String::from_utf8_lossy(&attr.value).to_string())
+                            }
+                            // r:id attribute — the local name is "id" with namespace prefix "r"
+                            _ => {
+                                let key = String::from_utf8_lossy(attr.key.as_ref());
+                                if key == "r:id"
+                                    || key.ends_with(":id") && attr.key.as_ref() != b"sheetId"
+                                {
+                                    r_id = Some(String::from_utf8_lossy(&attr.value).to_string());
+                                }
+                            }
+                        }
+                    }
+                    if let (Some(name), Some(r_id)) = (name, r_id) {
+                        if let Some(target) = rel_map.get(&r_id) {
+                            if target.starts_with("worksheets/") {
+                                sheets.push(SheetInfo {
+                                    name,
+                                    path: format!("xl/{target}"),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+            Ok(quick_xml::events::Event::Eof) => break,
+            Err(e) => return Err(ExtractionError::Xml(e.to_string())),
+            _ => {}
+        }
+    }
+    Ok(sheets)
+}
+
+fn col_to_index(col: &str) -> usize {
+    let mut idx: usize = 0;
+    for ch in col.bytes() {
+        idx = idx * 26 + (ch.to_ascii_uppercase() - b'A') as usize + 1;
+    }
+    idx.saturating_sub(1)
+}
+
+fn parse_sheet_rows(
+    xml: &str,
+    shared_strings: &[String],
+) -> Result<Vec<Vec<String>>, ExtractionError> {
+    let mut reader = quick_xml::Reader::from_str(xml);
+    let mut rows: Vec<Vec<String>> = Vec::new();
+    let mut current_row: HashMap<usize, String> = HashMap::new();
+    let mut max_col: usize = 0;
+    let mut in_row = false;
+    let mut cell_type: Option<String> = None;
+    let mut cell_col: usize = 0;
+    let mut in_cell = false;
+    let mut in_v = false;
+    let mut in_inline_t = false;
+    let mut cell_value = String::new();
+
+    loop {
+        match reader.read_event() {
+            Ok(quick_xml::events::Event::Start(ref e)) => {
+                let local = e.local_name();
+                match local.as_ref() {
+                    b"row" => {
+                        in_row = true;
+                        current_row.clear();
+                    }
+                    b"c" if in_row => {
+                        in_cell = true;
+                        cell_type = None;
+                        cell_col = 0;
+                        cell_value.clear();
+                        for attr in e.attributes().flatten() {
+                            match attr.key.as_ref() {
+                                b"r" => {
+                                    let r = String::from_utf8_lossy(&attr.value);
+                                    let col_str: String =
+                                        r.chars().take_while(|c| c.is_ascii_alphabetic()).collect();
+                                    if !col_str.is_empty() {
+                                        cell_col = col_to_index(&col_str);
+                                        if cell_col > max_col {
+                                            max_col = cell_col;
+                                        }
+                                    }
+                                }
+                                b"t" => {
+                                    cell_type =
+                                        Some(String::from_utf8_lossy(&attr.value).to_string());
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                    b"v" if in_cell => {
+                        in_v = true;
+                    }
+                    b"t" if in_cell => {
+                        // inline string <is><t>
+                        in_inline_t = true;
+                    }
+                    _ => {}
+                }
+            }
+            Ok(quick_xml::events::Event::Text(ref e)) => {
+                if in_v || in_inline_t {
+                    if let Ok(text) = e.unescape() {
+                        cell_value.push_str(&text);
+                    }
+                }
+            }
+            Ok(quick_xml::events::Event::End(ref e)) => {
+                let local = e.local_name();
+                match local.as_ref() {
+                    b"v" => in_v = false,
+                    b"t" if in_inline_t => in_inline_t = false,
+                    b"c" => {
+                        if in_cell {
+                            let value = if cell_type.as_deref() == Some("s") {
+                                // Shared string reference
+                                cell_value
+                                    .parse::<usize>()
+                                    .ok()
+                                    .and_then(|idx| shared_strings.get(idx))
+                                    .cloned()
+                                    .unwrap_or_default()
+                            } else {
+                                std::mem::take(&mut cell_value)
+                            };
+                            current_row.insert(cell_col, value);
+                            in_cell = false;
+                        }
+                    }
+                    b"row" => {
+                        if in_row && !current_row.is_empty() {
+                            let width = max_col + 1;
+                            let row: Vec<String> = (0..width)
+                                .map(|i| current_row.get(&i).cloned().unwrap_or_default())
+                                .collect();
+                            rows.push(row);
+                        }
+                        in_row = false;
+                    }
+                    _ => {}
+                }
+            }
+            Ok(quick_xml::events::Event::Eof) => break,
+            Err(e) => return Err(ExtractionError::Xml(e.to_string())),
+            _ => {}
+        }
+    }
+    Ok(rows)
+}
+
+fn escape_markdown_cell(v: &str) -> String {
+    v.replace('|', "\\|").replace('\n', " ")
+}
+
+fn format_rows_as_markdown(rows: &[Vec<String>]) -> String {
+    if rows.is_empty() {
+        return String::new();
+    }
+    let width = rows.iter().map(|r| r.len()).max().unwrap_or(0);
+    if width == 0 {
+        return String::new();
+    }
+
+    let mut output = String::new();
+
+    // Header row
+    let header: Vec<String> = (0..width)
+        .map(|i| {
+            rows[0]
+                .get(i)
+                .map(|v| escape_markdown_cell(v))
+                .unwrap_or_default()
+        })
+        .collect();
+    output.push_str("| ");
+    output.push_str(&header.join(" | "));
+    output.push_str(" |\n");
+
+    // Separator
+    output.push_str("| ");
+    output.push_str(&vec!["---"; width].join(" | "));
+    output.push_str(" |\n");
+
+    // Data rows
+    for row in rows.iter().skip(1) {
+        let cells: Vec<String> = (0..width)
+            .map(|i| {
+                row.get(i)
+                    .map(|v| escape_markdown_cell(v))
+                    .unwrap_or_default()
+            })
+            .collect();
+        output.push_str("| ");
+        output.push_str(&cells.join(" | "));
+        output.push_str(" |\n");
+    }
+    output
+}
+
+// ---------------------------------------------------------------------------
+// PDF extraction
+// ---------------------------------------------------------------------------
+
+fn extract_pdf(data: &[u8]) -> Result<String, ExtractionError> {
+    pdf_extract::extract_text_from_mem(data).map_err(|e| ExtractionError::Pdf(e.to_string()))
+}
+
+// ---------------------------------------------------------------------------
+// Truncation
+// ---------------------------------------------------------------------------
+
+fn truncate_to_limit(text: String) -> String {
+    if text.len() <= MAX_CHARS {
+        // Fast path: byte length is always >= char count for UTF-8,
+        // so if byte length fits, char count certainly fits.
+        return text;
+    }
+    let char_count = text.chars().count();
+    if char_count <= MAX_CHARS {
+        return text;
+    }
+    let truncated: String = text.chars().take(MAX_CHARS).collect();
+    format!("{truncated}{TRUNCATION_NOTICE}")
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build_test_zip(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        use std::io::Write;
+        let buf = Vec::new();
+        let cursor = std::io::Cursor::new(buf);
+        let mut writer = zip::ZipWriter::new(cursor);
+        let options = zip::write::SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Deflated);
+        for (name, content) in entries {
+            writer.start_file(name.to_string(), options).unwrap();
+            writer.write_all(content).unwrap();
+        }
+        writer.finish().unwrap().into_inner()
+    }
+
+    // -- is_extractable_mime --
+
+    #[test]
+    fn test_is_extractable_mime_supported() {
+        assert!(is_extractable_mime(
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        ));
+        assert!(is_extractable_mime(
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        ));
+        assert!(is_extractable_mime(
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        ));
+        assert!(is_extractable_mime("application/pdf"));
+    }
+
+    #[test]
+    fn test_is_extractable_mime_unsupported() {
+        assert!(!is_extractable_mime("image/png"));
+        assert!(!is_extractable_mime("text/plain"));
+        assert!(!is_extractable_mime("application/octet-stream"));
+        assert!(!is_extractable_mime("application/json"));
+    }
+
+    #[test]
+    fn test_is_extractable_mime_with_params() {
+        assert!(is_extractable_mime("application/pdf; charset=utf-8"));
+    }
+
+    // -- extract_text dispatch --
+
+    #[test]
+    fn test_extract_text_unsupported_returns_none() {
+        assert!(extract_text("image/png", &[]).unwrap().is_none());
+        assert!(extract_text("application/octet-stream", &[])
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn test_extract_text_supported_invalid_data_returns_err() {
+        assert!(extract_text("application/pdf", &[1, 2, 3]).is_err());
+        assert!(extract_text(
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            &[1, 2, 3]
+        )
+        .is_err());
+    }
+
+    // -- truncation --
+
+    #[test]
+    fn test_truncate_short_text() {
+        let text = "Hello, world!".to_string();
+        assert_eq!(truncate_to_limit(text.clone()), text);
+    }
+
+    #[test]
+    fn test_truncate_exceeds_limit() {
+        let text = "a".repeat(MAX_CHARS + 100);
+        let result = truncate_to_limit(text);
+        assert!(result.ends_with(TRUNCATION_NOTICE));
+        assert!(result.len() < MAX_CHARS + 200);
+    }
+
+    // -- DOCX tests --
+
+    #[test]
+    fn test_extract_docx_basic() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+        <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+          <w:body>
+            <w:p><w:r><w:t>Hello World</w:t></w:r></w:p>
+            <w:p><w:r><w:t>Second paragraph</w:t></w:r></w:p>
+          </w:body>
+        </w:document>"#;
+        let data = build_test_zip(&[("word/document.xml", xml.as_bytes())]);
+        let result = extract_docx(&data).unwrap();
+        assert_eq!(result, "Hello World\nSecond paragraph");
+    }
+
+    #[test]
+    fn test_extract_docx_multiple_runs() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+        <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+          <w:body>
+            <w:p>
+              <w:r><w:t>Hello </w:t></w:r>
+              <w:r><w:t>World</w:t></w:r>
+            </w:p>
+          </w:body>
+        </w:document>"#;
+        let data = build_test_zip(&[("word/document.xml", xml.as_bytes())]);
+        let result = extract_docx(&data).unwrap();
+        assert_eq!(result, "Hello World");
+    }
+
+    #[test]
+    fn test_extract_docx_empty() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+        <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+          <w:body></w:body>
+        </w:document>"#;
+        let data = build_test_zip(&[("word/document.xml", xml.as_bytes())]);
+        let result = extract_docx(&data).unwrap();
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn test_extract_docx_invalid_zip() {
+        assert!(extract_docx(&[0, 1, 2, 3]).is_err());
+    }
+
+    #[test]
+    fn test_extract_docx_missing_document_xml() {
+        let data = build_test_zip(&[("word/other.xml", b"<root/>")]);
+        assert!(extract_docx(&data).is_err());
+    }
+
+    // -- PPTX tests --
+
+    #[test]
+    fn test_extract_pptx_basic() {
+        let slide1 = r#"<?xml version="1.0" encoding="UTF-8"?>
+        <p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+               xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+          <p:cSld><p:spTree>
+            <p:sp><p:txBody>
+              <a:p><a:r><a:t>Title Slide</a:t></a:r></a:p>
+            </p:txBody></p:sp>
+          </p:spTree></p:cSld>
+        </p:sld>"#;
+        let slide2 = r#"<?xml version="1.0" encoding="UTF-8"?>
+        <p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+               xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+          <p:cSld><p:spTree>
+            <p:sp><p:txBody>
+              <a:p><a:r><a:t>Slide Two Content</a:t></a:r></a:p>
+            </p:txBody></p:sp>
+          </p:spTree></p:cSld>
+        </p:sld>"#;
+        let data = build_test_zip(&[
+            ("ppt/slides/slide1.xml", slide1.as_bytes()),
+            ("ppt/slides/slide2.xml", slide2.as_bytes()),
+        ]);
+        let result = extract_pptx(&data).unwrap();
+        assert!(result.contains("## Slide 1"));
+        assert!(result.contains("Title Slide"));
+        assert!(result.contains("## Slide 2"));
+        assert!(result.contains("Slide Two Content"));
+    }
+
+    #[test]
+    fn test_extract_pptx_no_slides() {
+        let data = build_test_zip(&[("ppt/other.xml", b"<root/>")]);
+        let result = extract_pptx(&data).unwrap();
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn test_extract_pptx_slide_ordering() {
+        let slide = |text: &str| {
+            format!(
+                r#"<?xml version="1.0"?>
+                <p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+                       xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+                  <p:cSld><p:spTree><p:sp><p:txBody>
+                    <a:p><a:r><a:t>{text}</a:t></a:r></a:p>
+                  </p:txBody></p:sp></p:spTree></p:cSld>
+                </p:sld>"#
+            )
+        };
+        // Insert in reverse order to test sorting
+        let data = build_test_zip(&[
+            ("ppt/slides/slide10.xml", slide("Ten").as_bytes()),
+            ("ppt/slides/slide2.xml", slide("Two").as_bytes()),
+            ("ppt/slides/slide1.xml", slide("One").as_bytes()),
+        ]);
+        let result = extract_pptx(&data).unwrap();
+        let lines: Vec<&str> = result.lines().collect();
+        let slide_headers: Vec<&&str> =
+            lines.iter().filter(|l| l.starts_with("## Slide")).collect();
+        assert_eq!(slide_headers.len(), 3);
+        assert_eq!(*slide_headers[0], "## Slide 1");
+        assert_eq!(*slide_headers[1], "## Slide 2");
+        assert_eq!(*slide_headers[2], "## Slide 3");
+    }
+
+    // -- XLSX tests --
+
+    #[test]
+    fn test_extract_xlsx_basic() {
+        let shared_strings = r#"<?xml version="1.0" encoding="UTF-8"?>
+        <sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="3">
+          <si><t>Name</t></si>
+          <si><t>Age</t></si>
+          <si><t>Alice</t></si>
+        </sst>"#;
+        let workbook = r#"<?xml version="1.0" encoding="UTF-8"?>
+        <workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+                  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+          <sheets>
+            <sheet name="Sheet1" sheetId="1" r:id="rId1"/>
+          </sheets>
+        </workbook>"#;
+        let rels = r#"<?xml version="1.0" encoding="UTF-8"?>
+        <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+          <Relationship Id="rId1" Target="worksheets/sheet1.xml"
+            Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
+        </Relationships>"#;
+        let sheet1 = r#"<?xml version="1.0" encoding="UTF-8"?>
+        <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+          <sheetData>
+            <row r="1">
+              <c r="A1" t="s"><v>0</v></c>
+              <c r="B1" t="s"><v>1</v></c>
+            </row>
+            <row r="2">
+              <c r="A2" t="s"><v>2</v></c>
+              <c r="B2"><v>30</v></c>
+            </row>
+          </sheetData>
+        </worksheet>"#;
+
+        let data = build_test_zip(&[
+            ("xl/sharedStrings.xml", shared_strings.as_bytes()),
+            ("xl/workbook.xml", workbook.as_bytes()),
+            ("xl/_rels/workbook.xml.rels", rels.as_bytes()),
+            ("xl/worksheets/sheet1.xml", sheet1.as_bytes()),
+        ]);
+        let result = extract_xlsx(&data).unwrap();
+        assert!(result.contains("## Sheet: Sheet1"));
+        assert!(result.contains("Name"));
+        assert!(result.contains("Age"));
+        assert!(result.contains("Alice"));
+        assert!(result.contains("30"));
+    }
+
+    #[test]
+    fn test_extract_xlsx_no_shared_strings() {
+        let workbook = r#"<?xml version="1.0" encoding="UTF-8"?>
+        <workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+                  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+          <sheets>
+            <sheet name="Data" sheetId="1" r:id="rId1"/>
+          </sheets>
+        </workbook>"#;
+        let rels = r#"<?xml version="1.0" encoding="UTF-8"?>
+        <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+          <Relationship Id="rId1" Target="worksheets/sheet1.xml"
+            Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"/>
+        </Relationships>"#;
+        let sheet1 = r#"<?xml version="1.0" encoding="UTF-8"?>
+        <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+          <sheetData>
+            <row r="1">
+              <c r="A1"><v>100</v></c>
+              <c r="B1"><v>200</v></c>
+            </row>
+          </sheetData>
+        </worksheet>"#;
+
+        let data = build_test_zip(&[
+            ("xl/workbook.xml", workbook.as_bytes()),
+            ("xl/_rels/workbook.xml.rels", rels.as_bytes()),
+            ("xl/worksheets/sheet1.xml", sheet1.as_bytes()),
+        ]);
+        let result = extract_xlsx(&data).unwrap();
+        assert!(result.contains("100"));
+        assert!(result.contains("200"));
+    }
+
+    // -- col_to_index --
+
+    #[test]
+    fn test_col_to_index() {
+        assert_eq!(col_to_index("A"), 0);
+        assert_eq!(col_to_index("B"), 1);
+        assert_eq!(col_to_index("Z"), 25);
+        assert_eq!(col_to_index("AA"), 26);
+        assert_eq!(col_to_index("AB"), 27);
+    }
+
+    // -- Markdown formatting --
+
+    #[test]
+    fn test_escape_markdown_cell() {
+        assert_eq!(escape_markdown_cell("hello"), "hello");
+        assert_eq!(escape_markdown_cell("a|b"), "a\\|b");
+        assert_eq!(escape_markdown_cell("line1\nline2"), "line1 line2");
+    }
+
+    #[test]
+    fn test_format_rows_as_markdown() {
+        let rows = vec![
+            vec!["A".to_string(), "B".to_string()],
+            vec!["1".to_string(), "2".to_string()],
+        ];
+        let md = format_rows_as_markdown(&rows);
+        assert!(md.contains("| A | B |"));
+        assert!(md.contains("| --- | --- |"));
+        assert!(md.contains("| 1 | 2 |"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ pub(crate) mod credential_store;
 mod discovery;
 mod error;
 mod executor;
+mod extraction;
 mod formatter;
 mod fs_util;
 mod generate_skills;

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -1288,20 +1288,48 @@ async fn execute_mcp_method(
                     "text": text_content.to_string()
                 }])
             } else {
-                json!([
-                    {
-                        "type": "resource",
-                        "resource": {
-                            "uri": format!("data:{};base64,", mime),
-                            "mimeType": mime,
-                            "blob": data
+                // Try text extraction for supported binary formats (docx, xlsx, pptx, pdf)
+                use base64::{engine::general_purpose::STANDARD, Engine as _};
+                let extracted = if crate::extraction::is_extractable_mime(mime) {
+                    STANDARD.decode(data).ok().and_then(|raw_bytes| {
+                        match crate::extraction::extract_text(mime, &raw_bytes) {
+                            Ok(Some(text)) => Some(text),
+                            Ok(None) => None,
+                            Err(e) => {
+                                tracing::warn!(
+                                    mime = mime,
+                                    error = %e,
+                                    "binary document text extraction failed"
+                                );
+                                None
+                            }
                         }
-                    },
-                    {
+                    })
+                } else {
+                    None
+                };
+
+                if let Some(text) = extracted {
+                    json!([{
                         "type": "text",
-                        "text": format!("Binary file downloaded ({} bytes, {})", bytes, mime)
-                    }
-                ])
+                        "text": text
+                    }])
+                } else {
+                    json!([
+                        {
+                            "type": "resource",
+                            "resource": {
+                                "uri": format!("data:{};base64,", mime),
+                                "mimeType": mime,
+                                "blob": data
+                            }
+                        },
+                        {
+                            "type": "text",
+                            "text": format!("Binary file downloaded ({} bytes, {})", bytes, mime)
+                        }
+                    ])
+                }
             }
         }
         Some(val) => {


### PR DESCRIPTION
## Summary

- Add server-side text extraction for binary documents (DOCX, XLSX, PPTX, PDF) in MCP tool responses
- Claude's MCP client discards `resource` blobs with unsupported MIME types, so binary files fetched via `drive.files.get` with `alt=media` were silently lost
- New `src/extraction.rs` module extracts text using `zip` + `quick-xml` (Office formats) and `pdf-extract` (PDF), returning content as `text` blocks instead of unusable `resource` blobs
- Graceful fallback: if extraction fails, the existing `resource` blob behavior is preserved

## Test plan

- [x] `cargo clippy -- -D warnings` passes with no warnings
- [x] `cargo test` — all 904 tests pass (20 new extraction tests), no regressions
- [ ] Manual: `gws mcp -s drive` → `drive.files.get` with `alt=media` on a .docx file → verify text returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)